### PR TITLE
Migrate to Grpc.Net.Client and refactor code

### DIFF
--- a/src/Nexutron.Protocol/Nexutron.Protocol.csproj
+++ b/src/Nexutron.Protocol/Nexutron.Protocol.csproj
@@ -16,13 +16,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Google.Api.CommonProtos" Version="2.15.0" />
-		<PackageReference Include="Google.Api.Gax" Version="4.8.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.26.1" />
-		<PackageReference Include="Google.Protobuf.Tools" Version="3.26.1" />
+		<PackageReference Include="Google.Api.CommonProtos" Version="2.16.0" />
+		<PackageReference Include="Google.Api.Gax" Version="4.9.0" />
+		<PackageReference Include="Google.Protobuf" Version="3.28.3" />
 		<PackageReference Include="Grpc" Version="2.46.6" />
-		<PackageReference Include="Grpc.Net.ClientFactory" Version="2.62.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.62.0">
+		<PackageReference Include="Grpc.Net.ClientFactory" Version="2.66.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.67.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/Nexutron/GrpcChannelClient.cs
+++ b/src/Nexutron/GrpcChannelClient.cs
@@ -1,33 +1,26 @@
-﻿using Grpc.Core;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Grpc.Net.Client;
 
-namespace Nexutron
+namespace Nexutron;
+
+class GrpcChannelClient : IGrpcChannelClient
 {
-    class GrpcChannelClient : IGrpcChannelClient
+    private readonly ILogger<GrpcChannelClient> _logger;
+    private readonly IOptions<NexutronOptions> _options;
+
+    public GrpcChannelClient(ILogger<GrpcChannelClient> logger, IOptions<NexutronOptions> options)
     {
-        private readonly ILogger<GrpcChannelClient> _logger;
-        private readonly IOptions<NexutronOptions> _options;
-
-        public GrpcChannelClient(ILogger<GrpcChannelClient> logger, IOptions<NexutronOptions> options)
-        {
-            _logger = logger;
-            _options = options;
-        }
-
-        public Channel GetProtocol()
-        {
-            return Helpers.GrpcChannelClientHelpers.GetProtocol(_options.Value.Channel.Host, _options.Value.Channel.Port);
-        }
-        public Channel GetSolidityProtocol()
-        {
-            return Helpers.GrpcChannelClientHelpers.GetSolidityProtocol(_options.Value.SolidityChannel.Host, _options.Value.SolidityChannel.Port);
-        }
+        _logger = logger;
+        _options = options;
     }
 
+    public GrpcChannel GetProtocol()
+    {
+        return Helpers.GrpcChannelClientHelpers.GetProtocol(_options.Value.Channel.Host, _options.Value.Channel.Port);
+    }
+    public GrpcChannel GetSolidityProtocol()
+    {
+        return Helpers.GrpcChannelClientHelpers.GetSolidityProtocol(_options.Value.SolidityChannel.Host, _options.Value.SolidityChannel.Port);
+    }
 }

--- a/src/Nexutron/Helpers/GrpcChannelClientHelpers.cs
+++ b/src/Nexutron/Helpers/GrpcChannelClientHelpers.cs
@@ -1,21 +1,28 @@
-﻿using Grpc.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
+using Grpc.Core;
+using Grpc.Net.Client;
 
-namespace Nexutron.Helpers
+namespace Nexutron.Helpers;
+
+public static class GrpcChannelClientHelpers
 {
-    public static class GrpcChannelClientHelpers
+    public static GrpcChannel GetProtocol(string host, int port)
     {
-        public static Channel GetProtocol(string host, int port)
+        var options = new GrpcChannelOptions
         {
-            return new Channel(host, port, ChannelCredentials.Insecure);
-        }
-        public static Channel GetSolidityProtocol(string host, int port)
+            Credentials = ChannelCredentials.SecureSsl
+        };
+
+        return GrpcChannel.ForAddress(new Uri($"https://{host}:{port}"), options);
+    }
+
+    public static GrpcChannel GetSolidityProtocol(string host, int port)
+    {
+        var options = new GrpcChannelOptions
         {
-            return new Channel(host, port, ChannelCredentials.Insecure);
-        }
+            Credentials = ChannelCredentials.SecureSsl
+        };
+
+        return GrpcChannel.ForAddress(new Uri($"https://{host}:{port}"), options);
     }
 }

--- a/src/Nexutron/Helpers/WalletClientHelper.cs
+++ b/src/Nexutron/Helpers/WalletClientHelper.cs
@@ -1,59 +1,59 @@
-﻿using Grpc.Core;
-using Nexutron.Protocol;
+﻿using Nexutron.Protocol;
 using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Net.Client;
 
-namespace Nexutron.Helpers
+namespace Nexutron.Helpers;
+
+public static class WalletClientHelper
 {
-    public static class WalletClientHelper
+    public static Wallet.WalletClient GetWalletClient(string host, int port)
     {
-        public static Wallet.WalletClient GetWalletClient(string host, int port)
-        {
-            return new Wallet.WalletClient(GrpcChannelClientHelpers.GetProtocol(host, port));
-        }
+        return new Wallet.WalletClient(GrpcChannelClientHelpers.GetProtocol(host, port));
+    }
 
-        public static Wallet.WalletClient GetWalletClient(Channel channel)
-        {
-            return new Wallet.WalletClient(channel);
-        }
+    public static Wallet.WalletClient GetWalletClient(GrpcChannel channel)
+    {
+        return new Wallet.WalletClient(channel);
+    }
 
-        public static WalletSolidity.WalletSolidityClient GetSolidityClient(string host, int port)
-        {
-            return new WalletSolidity.WalletSolidityClient(GrpcChannelClientHelpers.GetSolidityProtocol(host, port));
-        }
+    public static WalletSolidity.WalletSolidityClient GetSolidityClient(string host, int port)
+    {
+        return new WalletSolidity.WalletSolidityClient(GrpcChannelClientHelpers.GetSolidityProtocol(host, port));
+    }
 
-        public static WalletSolidity.WalletSolidityClient GetSolidityClient(Channel channel)
-        {
-            return new WalletSolidity.WalletSolidityClient(channel);
-        }
+    public static WalletSolidity.WalletSolidityClient GetSolidityClient(GrpcChannel channel)
+    {
+        return new WalletSolidity.WalletSolidityClient(channel);
+    }
 
-        public static EmptyMessage GetEmptyMessage()
-        {
-            return new EmptyMessage();
-        }
+    public static EmptyMessage GetEmptyMessage()
+    {
+        return new EmptyMessage();
+    }
 
-        public static NumberMessage GetNumberMessage(long number)
-        {
-            return new NumberMessage { Num = number };
-        }
+    public static NumberMessage GetNumberMessage(long number)
+    {
+        return new NumberMessage { Num = number };
+    }
 
-        public static async Task<BlockExtention> GetBlockExtention(Wallet.WalletClient wallet, string apiKey)
-        {
-            return await wallet.GetNowBlock2Async(new EmptyMessage(), headers: WalletHelper.GetHeaders(apiKey));
-        }
+    public static async Task<BlockExtention> GetBlockExtention(Wallet.WalletClient wallet, string apiKey)
+    {
+        return await wallet.GetNowBlock2Async(new EmptyMessage(), headers: WalletHelper.GetHeaders(apiKey));
+    }
 
-        public static async Task<BlockExtention> GetBlockExtention(Wallet.WalletClient wallet, Metadata headers)
-        {
-            return await wallet.GetNowBlock2Async(new EmptyMessage(), headers: headers);
-        }
+    public static async Task<BlockExtention> GetBlockExtention(Wallet.WalletClient wallet, Metadata headers)
+    {
+        return await wallet.GetNowBlock2Async(new EmptyMessage(), headers: headers);
+    }
 
-        public static async Task<Return> BroadcastTransactionAsync(Wallet.WalletClient wallet, Transaction transaction, string apiKey)
-        {
-            return await wallet.BroadcastTransactionAsync(transaction, headers: WalletHelper.GetHeaders(apiKey));
-        }
+    public static async Task<Return> BroadcastTransactionAsync(Wallet.WalletClient wallet, Transaction transaction, string apiKey)
+    {
+        return await wallet.BroadcastTransactionAsync(transaction, headers: WalletHelper.GetHeaders(apiKey));
+    }
 
-        public static async Task<Return> BroadcastTransactionAsync(Wallet.WalletClient wallet, Transaction transaction, Metadata headers)
-        {
-            return await wallet.BroadcastTransactionAsync(transaction, headers: headers);
-        }
+    public static async Task<Return> BroadcastTransactionAsync(Wallet.WalletClient wallet, Transaction transaction, Metadata headers)
+    {
+        return await wallet.BroadcastTransactionAsync(transaction, headers: headers);
     }
 }

--- a/src/Nexutron/Helpers/WalletHelper.cs
+++ b/src/Nexutron/Helpers/WalletHelper.cs
@@ -1,20 +1,16 @@
-﻿using Google.Protobuf;
-using Grpc.Core;
-using Nexutron.Crypto;
-using System;
+﻿using Grpc.Core;
 
-namespace Nexutron.Helpers
+namespace Nexutron.Helpers;
+
+public static class WalletHelper
 {
-    public static class WalletHelper
+    public static Metadata GetHeaders(string apiKey)
     {
-        public static Metadata GetHeaders(string apiKey)
+        var headers = new Metadata
         {
-            var headers = new Metadata
-            {
-                { "TRON-PRO-API-KEY", apiKey }
-            };
+            { "TRON-PRO-API-KEY", apiKey }
+        };
 
-            return headers;
-        }
+        return headers;
     }
 }

--- a/src/Nexutron/IGrpcChannelClient.cs
+++ b/src/Nexutron/IGrpcChannelClient.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Grpc.Net.Client;
 
-namespace Nexutron
+namespace Nexutron;
+
+public interface IGrpcChannelClient
 {
-    public interface IGrpcChannelClient
-    {
-        
-        Grpc.Core.Channel GetProtocol();
-        Grpc.Core.Channel GetSolidityProtocol();
-    }
+    GrpcChannel GetProtocol();
+    GrpcChannel GetSolidityProtocol();
 }

--- a/src/Nexutron/WalletClient.cs
+++ b/src/Nexutron/WalletClient.cs
@@ -5,43 +5,39 @@ using Nexutron.Accounts;
 using Nexutron.Helpers;
 using Nexutron.Protocol;
 
-namespace Nexutron
+namespace Nexutron;
+
+public class WalletClient(IGrpcChannelClient channelClient, IOptions<NexutronOptions> options) : IWalletClient
 {
-    class WalletClient(IGrpcChannelClient channelClient, IOptions<NexutronOptions> options) : IWalletClient
+    public Wallet.WalletClient GetWalletClient()
     {
-        private readonly IGrpcChannelClient _channelClient = channelClient;
-        private readonly IOptions<NexutronOptions> _options = options;
+        var channel = channelClient.GetProtocol();
+        return WalletClientHelper.GetWalletClient(channel);
+    }
 
-        public Wallet.WalletClient GetWalletClient()
-        {
-            var channel = _channelClient.GetProtocol();
-            return WalletClientHelper.GetWalletClient(channel);
-        }
+    public ITronAccount GenerateAccount()
+    {
+        return AccountHelper.GenerateAccount();
+    }
 
-        public ITronAccount GenerateAccount()
-        {
-            return AccountHelper.GenerateAccount();
-        }
+    public ITronAccount GetAccount(string privateKey)
+    {
+        return AccountHelper.GetAccount(privateKey);
+    }
 
-        public ITronAccount GetAccount(string privateKey)
-        {
-            return AccountHelper.GetAccount(privateKey);
-        }
+    public WalletSolidity.WalletSolidityClient GetSolidityClient()
+    {
+        var channel = channelClient.GetSolidityProtocol();
+        return WalletClientHelper.GetSolidityClient(channel);
+    }
 
-        public WalletSolidity.WalletSolidityClient GetSolidityClient()
-        {
-            var channel = _channelClient.GetSolidityProtocol();
-            return WalletClientHelper.GetSolidityClient(channel);
-        }
+    public ByteString ParseAddress(string address)
+    {
+        return AccountHelper.ParseAddress(address);
+    }
 
-        public ByteString ParseAddress(string address)
-        {
-            return AccountHelper.ParseAddress(address);
-        }
-
-        public Metadata GetHeaders()
-        {
-            return WalletHelper.GetHeaders(_options.Value.ApiKey);
-        }
+    public Metadata GetHeaders()
+    {
+        return WalletHelper.GetHeaders(options.Value.ApiKey);
     }
 }


### PR DESCRIPTION
Updated package references in `Nexutron.Protocol.csproj` to newer versions for `Google.Api.CommonProtos`, `Google.Api.Gax`, `Google.Protobuf`, `Grpc.Net.ClientFactory`, and `Grpc.Tools`.

Replaced `Grpc.Core.Channel` with `Grpc.Net.Client.GrpcChannel` in multiple files including `GrpcChannelClient.cs`, `GrpcChannelClientHelpers.cs`, `WalletClientHelper.cs`, `IGrpcChannelClient.cs`, and `WalletClient.cs`.

Removed unused `using` directives in several files.

Refactored `GrpcChannelClient` and `WalletClient` classes to use `Grpc.Net.Client.GrpcChannel` and dependency injection.

Simplified methods in `GrpcChannelClientHelpers`, `WalletClientHelper`, and `WalletHelper` to use `Grpc.Net.Client.GrpcChannel` and return `Metadata` directly.